### PR TITLE
feature/2 error when using same client id

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -266,6 +266,11 @@ async fn handle_single_websocket(
     client_id: String,
 ) {
     info!("WebSocket connected for client_id: {}", client_id);
+    if app_state.active_websockets.contains_key(&client_id) {
+        error!("Client ID '{}' already exists. Rejecting connection.", client_id);
+        let _ = socket.close().await;
+        return;
+    }
     let (tx, mut rx) = tokio::sync::mpsc::channel::<Message>(100);
     app_state.active_websockets.insert(client_id.clone(), tx);
 


### PR DESCRIPTION
- **feat(server): can't use already existing client id**
- **style: run `cargo fmt`**

Closes #2 