### PR TITLE
Bug/root path not correct

### DIFF
--- a/client/src/http_handler.rs
+++ b/client/src/http_handler.rs
@@ -1,8 +1,8 @@
 use crate::models::{TunneledHttpResponse, TunneledRequest};
 use base64::{engine::general_purpose, Engine};
 use reqwest::{Client, Method as ReqwestMethod};
-use tungstenite::http::HeaderValue;
 use tracing::{error, info, warn};
+use tungstenite::http::HeaderValue;
 
 pub async fn forward_request_to_local_service(
     http_client: &Client,
@@ -75,7 +75,9 @@ pub async fn forward_request_to_local_service(
                         id: tunneled_req.id,
                         status: 400,
                         headers: std::collections::HashMap::new(),
-                        body: Some(general_purpose::STANDARD.encode("Failed to decode request body")),
+                        body: Some(
+                            general_purpose::STANDARD.encode("Failed to decode request body"),
+                        ),
                     };
                 }
             }
@@ -92,8 +94,10 @@ pub async fn forward_request_to_local_service(
             let status = resp.status().as_u16();
             let mut headers_map = std::collections::HashMap::new();
             for (key, value) in resp.headers() {
-                headers_map
-                    .insert(key.to_string(), value.to_str().unwrap_or_default().to_string());
+                headers_map.insert(
+                    key.to_string(),
+                    value.to_str().unwrap_or_default().to_string(),
+                );
             }
 
             let body_bytes = match resp.bytes().await {

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -60,22 +60,7 @@ async fn main() {
         info!("WebSocket sender task shutting down.");
     });
 
-    let client_public_url_base = config
-        .server_ws_url
-        .replace("ws://", "http://")
-        .replace("wss://", "https://")
-        .trim_end_matches("/ws")
-        .to_string();
-
-    println!("\nYour tunnel is active! Requests to:");
-    config.allowed_paths.iter().for_each(|path| {
-        println!("  {}/{}{}", client_public_url_base, config.client_id, path);
-    });
-    
-    println!(
-        "Will be forwarded to your local service at: {}",
-        config.target_http_service_url
-    );
+    print_tunnel_status(&config);
 
     let http_client = Client::builder()
         .timeout(Duration::from_secs(30))
@@ -85,4 +70,29 @@ async fn main() {
     handle_websocket_messages(ws_receiver, tx, http_client, config).await;
 
     info!("Rust Tunnel Client shutting down.");
+}
+
+fn print_tunnel_status(config: &AppConfig) {
+    let client_public_url_base = config
+        .server_ws_url
+        .replace("ws://", "http://")
+        .replace("wss://", "https://")
+        .trim_end_matches("/ws")
+        .to_string();
+
+    println!("\n🚀 Your tunnel is active!");
+
+    if config.allowed_paths.is_empty() {
+        println!("No public paths are configured. No remote requests will be forwarded.");
+    } else {
+        println!("Requests to:");
+        for path in &config.allowed_paths {
+            println!("  {}/{}{}", client_public_url_base, config.client_id, path);
+        }
+    }
+
+    println!(
+        "\nWill be forwarded to your local service at: {}",
+        config.target_http_service_url
+    );
 }

--- a/client/src/websocket_handler.rs
+++ b/client/src/websocket_handler.rs
@@ -1,17 +1,13 @@
 use crate::config::AppConfig;
 use crate::http_handler::forward_request_to_local_service;
 use crate::models::{TunneledHttpResponse, TunneledRequest};
-use futures_util::{
-    stream::{SplitSink, SplitStream, StreamExt},
-};
+use futures_util::stream::{SplitSink, SplitStream, StreamExt};
 use reqwest::Client;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
-use tokio_tungstenite::{
-    connect_async, tungstenite, MaybeTlsStream, WebSocketStream,
-};
 use tokio_tungstenite::tungstenite::protocol::Message as WsMessage;
+use tokio_tungstenite::{connect_async, tungstenite, MaybeTlsStream, WebSocketStream};
 use tracing::{debug, error, info};
 use tungstenite::handshake::client::Request;
 use tungstenite::http::header::AUTHORIZATION;
@@ -27,9 +23,7 @@ pub async fn connect_to_websocket(
     let allowed_paths_query = config.allowed_paths.join(",");
     let ws_url = Url::parse(&format!(
         "{}?client_id={}&allowed_paths={}",
-        config.server_ws_url,
-        config.client_id,
-        allowed_paths_query
+        config.server_ws_url, config.client_id, allowed_paths_query
     ))?;
 
     let auth_header_value = format!("Bearer {}", config.secret_token);
@@ -43,10 +37,7 @@ pub async fn connect_to_websocket(
         .header("Connection", "upgrade")
         .header("Sec-Websocket-Key", generate_key())
         .header("Sec-Websocket-Version", "13")
-        .header(
-            AUTHORIZATION,
-            HeaderValue::from_str(&auth_header_value)?,
-        )
+        .header(AUTHORIZATION, HeaderValue::from_str(&auth_header_value)?)
         .body(())?;
 
     info!("Connecting to WebSocket server at {}", ws_url);

--- a/server/src/forwarding.rs
+++ b/server/src/forwarding.rs
@@ -111,50 +111,6 @@ async fn handle_forwarding_request(
 }
 
 #[axum::debug_handler]
-pub async fn forward_handler_no_path(
-    State(app_state): State<Arc<AppState>>,
-    Path(client_id): Path<String>,
-    Query(query_params): Query<HashMap<String, String>>,
-    method: Method,
-    headers: HeaderMap,
-    body: bytes::Bytes,
-) -> Response {
-    let forward_path = "/".to_string();
-    handle_forwarding_request(
-        app_state,
-        client_id,
-        method,
-        headers,
-        body,
-        forward_path,
-        query_params,
-    )
-    .await
-}
-
-#[axum::debug_handler]
-pub async fn forward_handler_with_path(
-    State(app_state): State<Arc<AppState>>,
-    Path((client_id, path)): Path<(String, String)>,
-    Query(query_params): Query<HashMap<String, String>>,
-    method: Method,
-    headers: HeaderMap,
-    body: bytes::Bytes,
-) -> Response {
-    let forward_path = format!("/{}", path);
-    handle_forwarding_request(
-        app_state,
-        client_id,
-        method,
-        headers,
-        body,
-        forward_path,
-        query_params,
-    )
-    .await
-}
-
-#[axum::debug_handler]
 pub async fn forward_handler(
     State(app_state): State<Arc<AppState>>,
     Path(path): Path<String>,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -50,9 +50,6 @@ async fn main() {
     let app = Router::new()
         .route("/ws", get(websocket::ws_handler))
         .route("/*path", any(forwarding::forward_handler))
-        //.route("/:client_id", any(forwarding::forward_handler_no_path))
-        //.route("/*path", any(forwarding::forward_handler_no_path))
-        //.route("/:client_id/*path",any(forwarding::forward_handler_with_path),
         .with_state(app_state);
 
     let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -49,11 +49,10 @@ async fn main() {
 
     let app = Router::new()
         .route("/ws", get(websocket::ws_handler))
-        .route("/:client_id", any(forwarding::forward_handler_no_path))
-        .route(
-            "/:client_id/*path",
-            any(forwarding::forward_handler_with_path),
-        )
+        .route("/*path", any(forwarding::forward_handler))
+        //.route("/:client_id", any(forwarding::forward_handler_no_path))
+        //.route("/*path", any(forwarding::forward_handler_no_path))
+        //.route("/:client_id/*path",any(forwarding::forward_handler_with_path),
         .with_state(app_state);
 
     let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();


### PR DESCRIPTION
This PR solves #15 where forwarding to root with trailing slash would not work.

These changes remove some duplicate code, and move the logic of the path splitting into the forward path method instead.

It also refines the way users add paths a bit for better usability.